### PR TITLE
Revert Torrents are now resumed on add by default.

### DIFF
--- a/dir_climber.py
+++ b/dir_climber.py
@@ -57,6 +57,6 @@ for subdir, dirs, files in os.walk(input_dir):
             # iterating through .torrents and adding the file to client, with respective path set
             # Prints "Ok." if the file is added fine, "Fails." if the file addition failed.
             try:
-                print(qb_client.torrents_add(torrent_files=f"./temp/{file}/{torrent.name}", save_path=os.path.join(subdir), is_skip_checking=True, is_paused=False, content_layout="NoSubfolder", tags="CrossSeedAutoDL"))
+                print(qb_client.torrents_add(torrent_files=f"./temp/{file}/{torrent.name}", save_path=os.path.join(subdir), is_skip_checking=True, is_paused=True, content_layout="NoSubfolder", tags="CrossSeedAutoDL"))
             except:
                 continue


### PR DESCRIPTION
Adding not as paused causes x-seeds to fail. Meaning the torrents are added; yet rather then x-seed and use existing data they download the whole torrent.

Killed my Ratio on BTN 1G/600G due to downloading all of the "cross seeds"